### PR TITLE
Create substructure "Opaque" that contains all the structures for opaque types.

### DIFF
--- a/smlfut.1
+++ b/smlfut.1
@@ -101,7 +101,9 @@ sig
 
   (* Array type definitions... *)
 
-  (* Opaque type definitions... *)
+  structure Opaque : sig
+    (* Opaque type specs... *)
+  end
 
   structure Entry : sig
     (* Entry points... *)

--- a/test/test_main.sml
+++ b/test/test_main.sml
@@ -94,11 +94,11 @@ fun test_fails ctx =
 
 fun test_record ctx =
   let
-    val record = Futhark.opaque_record.new ctx {a = 2, b = true}
-    val {a, b} = Futhark.opaque_record.values record
+    val record = Futhark.Opaque.record.new ctx {a = 2, b = true}
+    val {a, b} = Futhark.Opaque.record.values record
   in
     if a <> 2 orelse b <> true then raise Fail "Unexpected result." else ();
-    Futhark.opaque_record.free record
+    Futhark.Opaque.record.free record
   end
 
 val () =


### PR DESCRIPTION
This is instead of having all the structures for opaque types immediately inside the top level structure.  It is the difference between the Futhark type `foo` being called `Futhark.Opaque.foo.t` and `Futhark.opaque_foo.t`.  In particular, it means the Futhark type name maps *directly* to a (structure) identifier in SML.  In particular, this means you can actually follow the SML Basis Library naming scheme if you also pick your Futhark type names appropriately.  The downside is a yet more nested module structure.

@kfl, Martin appointed you as having good SML taste.  What do you think?

@shwestrick, you are also the target audience here.  Do you think this is better?